### PR TITLE
Fix broken links in audit log exports

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -10,7 +10,7 @@ copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software. 6o0wS19R2p
+copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,


### PR DESCRIPTION
Resolved issues causing links in exported audit logs to be broken or inaccessible.